### PR TITLE
ci: limit discord job to master branch

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,6 +1,9 @@
 name: PushMessage
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   notify:


### PR DESCRIPTION
Limit discord job to master branch due to not needing extra branch definitions.